### PR TITLE
Add signature after quoted text when replying

### DIFF
--- a/reader/EmailReaderWindow.cpp
+++ b/reader/EmailReaderWindow.cpp
@@ -2132,8 +2132,8 @@ EmailReaderWindow::Reply(entry_ref* ref, EmailReaderWindow* window, uint32 type)
 
 	fReplying = true;
 
-	// Add auto-signature before the quoted text
-	AddAutoSignature(true);
+	// Add auto-signature after the quoted text
+	AddAutoSignature(false);
 }
 
 
@@ -2212,8 +2212,8 @@ EmailReaderWindow::ComposeReplyTo(entry_ref* ref, uint32 type)
 
 	fReplying = true;
 	
-	// Add auto-signature before the quoted text
-	AddAutoSignature(true);
+	// Add auto-signature after the quoted text
+	AddAutoSignature(false);
 	
 	// Keep sourceMail alive — TTextView::fMail references it for quoted text,
 	// and it must outlive the compose window.


### PR DESCRIPTION
Similar to Haiku's Mail app, and frankly the only correct way. :)

Forwarded mails still have the original's mail after the signature. I figure that when you forward an email, you want to sent it in it's entirety, below some descriptive intro at the top.

Fixes #21