### PR TITLE
Add shortcuts to "Mark as read" and preferences

### DIFF
--- a/EmailViews.cpp
+++ b/EmailViews.cpp
@@ -759,7 +759,7 @@ EmailViewsWindow::EmailViewsWindow()
                                           new BMessage(MSG_ABOUT)));
     mailViewerMenu->AddSeparatorItem();
     BMenuItem* emailSettingsItem = new BMenuItem(B_TRANSLATE("Email preferences" B_UTF8_ELLIPSIS), 
-                                          new BMessage(M_PREFS));
+                                          new BMessage(M_PREFS), ',');
     emailSettingsItem->SetTarget(be_app);
     mailViewerMenu->AddItem(emailSettingsItem);
     mailViewerMenu->AddItem(new BMenuItem(B_TRANSLATE("Email accounts" B_UTF8_ELLIPSIS), 
@@ -778,7 +778,7 @@ EmailViewsWindow::EmailViewsWindow()
     messagesMenu->AddItem(new BMenuItem(B_TRANSLATE("Reply all"), new BMessage(MSG_REPLY_ALL), 'R', B_SHIFT_KEY));
     messagesMenu->AddItem(new BMenuItem(B_TRANSLATE("Forward"), new BMessage(MSG_FORWARD), 'F', B_SHIFT_KEY));
     messagesMenu->AddSeparatorItem();
-    fMarkReadMenuItem = new BMenuItem(B_TRANSLATE("Mark as read"), new BMessage(MSG_MARK_READ));
+    fMarkReadMenuItem = new BMenuItem(B_TRANSLATE("Mark as read"), new BMessage(MSG_MARK_READ), 'M');
     fMarkReadMenuItem->SetEnabled(false);
     messagesMenu->AddItem(fMarkReadMenuItem);
     fMarkUnreadMenuItem = new BMenuItem(B_TRANSLATE("Mark as unread"), new BMessage(MSG_MARK_UNREAD));


### PR DESCRIPTION
I find myself often wanting to mark an email as read, because I've read enough in the preview. I almost never want to mark an already read email as "New". So I believe having just one shortcut for "Mark as read" (ALT+M) should be enough.

',' is the standard shortcut for preferences.
I don't think the "Email accounts" are needed often after the initial setup, so we don't need a sortcut here.

